### PR TITLE
Ping Podcast Index after RSS build

### DIFF
--- a/scripts/build-rss.ts
+++ b/scripts/build-rss.ts
@@ -657,6 +657,20 @@ async function buildRSS() {
     console.log('📡 Feed will be available at: /rss.xml');
     console.log('🏥 Health check available at: /rss-health');
 
+    // Notify Podcast Index that the feed has been updated
+    const feedUrl = `${baseUrl}/rss.xml`;
+    try {
+      const piUrl = `https://api.podcastindex.org/api/1.0/hub/pubnotify?url=${encodeURIComponent(feedUrl)}&pretty`;
+      const piResponse = await fetch(piUrl);
+      if (piResponse.ok) {
+        console.log(`📡 Notified Podcast Index of feed update`);
+      } else {
+        console.warn(`⚠️ Podcast Index notification returned status ${piResponse.status}`);
+      }
+    } catch (error) {
+      console.warn('⚠️ Failed to notify Podcast Index:', (error as Error).message);
+    }
+
     process.exit(0);
   } catch (error) {
     console.error('❌ Error generating RSS feed:', error);


### PR DESCRIPTION
## Summary
- Notifies Podcast Index via `/hub/pubnotify` after the RSS feed is generated so the directory re-crawls automatically
- No API key required — uses the public endpoint
- Non-fatal: failures are logged as warnings, build still succeeds
- No new dependencies — uses native `fetch()`

## Test plan
- [x] `npm test` passes (TypeScript + ESLint + Vitest + build)
- [ ] Verify build output shows the notification log line
- [ ] Confirm Podcast Index picks up feed changes faster after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)